### PR TITLE
Add dependencies jackson-databind and jackson-dataformat-msgpack to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,5 +126,14 @@
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.msgpack</groupId>
+			<artifactId>jackson-dataformat-msgpack</artifactId>
+			<version>0.9.5</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This PR adds the dependencies com.fasterxml.jackson.core.jackson-databind and org.msgpack.jackson-dataformat-msgpack version 0.9.5 to the pom.xml

Without these dependencies, it seems not to be possible to build this project. I observed two missing imports in 
https://github.com/bioimage-io/JDLL/blob/main/src/main/java/io/bioimage/modelrunner/bioimageio/bioengine/BioengineInterface.java, import org.msgpack.jackson.dataformat.MessagePackFactory; and import com.fasterxml.jackson.databind.ObjectMapper;

These 2 imports are not missing anymore, after the 2 new dependencies have been added to the pom.xml