### PR TITLE
Avoid NullPointerException in DownloadTracker

### DIFF
--- a/src/main/java/io/bioimage/modelrunner/bioimageio/download/DownloadTracker.java
+++ b/src/main/java/io/bioimage/modelrunner/bioimageio/download/DownloadTracker.java
@@ -293,18 +293,23 @@ public class DownloadTracker {
 			keep = false;
 			for (int i = 0; i < this.remainingFiles.size(); i ++) {
 				File ff = remainingFiles.get(i);
-				if (ff.isFile() && ff.length() < this.sizeFiles.get(ff.getAbsolutePath())){
-					consumer.accept(ff.getAbsolutePath(), Math.min(1, (double) (ff.length()) / (double) this.sizeFiles.get(ff.getAbsolutePath())));
+				Long storedValue = this.sizeFiles.get( ff.getAbsolutePath() );
+				long fileSize = storedValue != null ? storedValue : -1;
+				if ( ff.isFile() && ff.length() < fileSize )
+				{
+					consumer.accept( ff.getAbsolutePath(), Math.min( 1, ( double ) ( ff.length() ) / fileSize ) );
 					consumer.accept(TOTAL_PROGRESS_KEY, (double) (totalDownloadSize + ff.length()) / (double) totalSize);
 					break;
 				} else if (remainingFiles.get(i).isFile()) {
 					consumer.accept(ff.getAbsolutePath(), 1.0);
-					totalDownloadSize += (double) this.sizeFiles.get(ff.getAbsolutePath());
+					totalDownloadSize += fileSize;
 					consumer.accept(TOTAL_PROGRESS_KEY, (double) (totalDownloadSize) / (double) totalSize);
 					remainingFiles.remove(i);
 					keep = true;
 					break;
-				} else if (this.sizeFiles.get(ff.getAbsolutePath()) == -1) {
+				}
+				else if ( fileSize == -1 )
+				{
 					consumer.accept(ff.getAbsolutePath(), -0.01);
 					remainingFiles.remove(i);
 					keep = true;


### PR DESCRIPTION
The intention of this of Pull Request is to avoid a `NullPointerException` printed out to the console during the process of downloading files needed for engines that have not yet been download.

Current state: 
![grafik](https://github.com/bioimage-io/JDLL/assets/10515534/9df56369-65fb-40e7-8c13-cd2aa6fa1348)

The `NullPointerException` actually is not really a problem. The download works as intended even after the Exception occurs. However, the Exception can be confusing to users and made me think, I should stop the process, because there was an exception while trying to download.

The changes of this Pull Request lead to this situation instead:
![grafik](https://github.com/bioimage-io/JDLL/assets/10515534/b4cd123e-f3d6-48ea-82f3-ecfa9d03de26)

I am not totally sure, if this reflects the initial intention of the download tracker.
