### PR TITLE
Update Cellpose.java - Fix treatment of backslahes in file paths

### DIFF
--- a/src/main/java/io/bioimage/modelrunner/model/special/cellpose/Cellpose.java
+++ b/src/main/java/io/bioimage/modelrunner/model/special/cellpose/Cellpose.java
@@ -124,7 +124,7 @@ public class Cellpose extends BioimageIoModelPytorchProtected {
 			+ "if 'shared_memory' not in globals().keys():" + System.lineSeparator()
 			+ "  from multiprocessing import shared_memory" + System.lineSeparator()
 			+ "  globals()['shared_memory'] = shared_memory" + System.lineSeparator()
-			+ MODEL_VAR_NAME + " = denoise.CellposeDenoiseModel(gpu=%s, pretrained_model='%s')" + System.lineSeparator()
+			+ MODEL_VAR_NAME + " = denoise.CellposeDenoiseModel(gpu=%s, pretrained_model=r'%s')" + System.lineSeparator()
 			+ "globals()['" + MODEL_VAR_NAME + "'] = " + MODEL_VAR_NAME + System.lineSeparator();
 	
 	protected static final String PATH_TO_RDF = "special_models/cellpose/rdf.yaml";


### PR DESCRIPTION
This change lets Python treat the backslashes of filepaths literally.

In Windows environments, a path such as 'C:\Users\' is not uncommon. However, Python interprets '\U' as a start to Unicode escape sequence, which is unintended and leads to an error, since the Unicode escape sequence is never ended.