### PR TITLE
Remove printing stack trace in BioimageioRepo.java

### DIFF
--- a/src/main/java/io/bioimage/modelrunner/bioimageio/BioimageioRepo.java
+++ b/src/main/java/io/bioimage/modelrunner/bioimageio/BioimageioRepo.java
@@ -209,9 +209,9 @@ public class BioimageioRepo {
 				// the descriptor from the yaml file
 				if (verbose) {
 					String errMSg = "Could not load descriptor for the Bioimage.io model " + jsonResource.get("concept") + ".";
+					errMSg += "\n" + ex.getMessage();
 					Log.addProgressAndShowInTerminal(consumer, errMSg, true);
 				}
-                ex.printStackTrace();
 			}
 		}
 		return MODELS;


### PR DESCRIPTION
Printing the stack trace in this may pollute the logging window, even though, it is actually not required. Users may choose verbose=true in this method, if they want more process internal information